### PR TITLE
Avoid producing additional JetToolBox format files

### DIFF
--- a/python/jettoolbox_settings.py
+++ b/python/jettoolbox_settings.py
@@ -104,8 +104,9 @@ def jettoolbox_settings( process , runMC ):
         Cut                = ''
     )
 
-    #Avoid producing additional JetToolBox format files, kick out the "EndPath" attribute of process.
+    #To avoid producing additional JetToolBox format files, kick out the "EndPath" attribute of process.
     #Aditionally remove the unscheduled mode added by JetToolBox which results in segmentation violation???
+    #(temporary!!)
     delattr(process, 'endpath')
 
     # Required because allowedUnsheduled is broken?

--- a/python/jettoolbox_settings.py
+++ b/python/jettoolbox_settings.py
@@ -104,8 +104,9 @@ def jettoolbox_settings( process , runMC ):
         Cut                = ''
     )
 
-    #Avoid producing additional JetToolBox format files
-    delattr(process, 'edmOut')
+    #Avoid producing additional JetToolBox format files, kick out the "EndPath" attribute of process.
+    #Aditionally remove the unscheduled mode added by JetToolBox which results in segmentation violation???
+    delattr(process, 'endpath')
 
     # Required because allowedUnsheduled is broken?
     # Or the jetttoolbox is not adding all the sequences

--- a/python/jettoolbox_settings.py
+++ b/python/jettoolbox_settings.py
@@ -104,6 +104,9 @@ def jettoolbox_settings( process , runMC ):
         Cut                = ''
     )
 
+    #Avoid producing additional JetToolBox format files
+    delattr(process, 'edmOut')
+
     # Required because allowedUnsheduled is broken?
     # Or the jetttoolbox is not adding all the sequences
     process.ak4chs = cms.Sequence(


### PR DESCRIPTION
To avoid producing additional JetToolBox format files, kick out the "EndPath" attribute of process. Aditionally remove the unscheduled mode added by JetToolBox which results in segmentation violation?? 
This is temporary change which depends on the JetToolBox update.