### PR TITLE
Fix a big problem which electron ID can not be catched

### DIFF
--- a/production/bprimeKit_cfg.py
+++ b/production/bprimeKit_cfg.py
@@ -130,6 +130,7 @@ process.bprimeKit = mysetting.bprimeKit
 
 process.Path = cms.Path(
 #    process.jettoolboxseq *
+    process.egmGsfElectronIDSequence*
     process.bprimeKit,
     jettoolboxTask
 )

--- a/src/LeptonNtuplizer_Electron.cc
+++ b/src/LeptonNtuplizer_Electron.cc
@@ -97,15 +97,11 @@ LeptonNtuplizer::FillElectron( const edm::Event& iEvent, const edm::EventSetup& 
 
     // ----- Isolation variables  -----------------------------------------------------------------------
     const edm::Ptr<pat::Electron> el( _electronhandle, it_el - _electronhandle->begin() );
-    try {
-      LepInfo.EgammaCutBasedEleIdVETO   [LepInfo.Size] = (int)( ( *_electronIDVeto )[el] );
-      LepInfo.EgammaCutBasedEleIdLOOSE  [LepInfo.Size] = (int)( ( *_electronIDLoose )[el] );
-      LepInfo.EgammaCutBasedEleIdMEDIUM [LepInfo.Size] = (int)( ( *_electronIDMedium )[el] );
-      LepInfo.EgammaCutBasedEleIdTIGHT  [LepInfo.Size] = (int)( ( *_electronIDTight )[el] );
-      // LepInfo.EgammaCutBasedEleIdHEEP   [LepInfo.Size] = (int)((*fElectronIDHEEP_H)[el]);
-    } catch( cms::Exception& x ){
-      // cout << "Weird electron found!" << endl;
-    }
+    LepInfo.EgammaCutBasedEleIdVETO     [LepInfo.Size] = (int)( ( *_electronIDVeto )[el] );
+    LepInfo.EgammaCutBasedEleIdLOOSE    [LepInfo.Size] = (int)( ( *_electronIDLoose )[el] );
+    LepInfo.EgammaCutBasedEleIdMEDIUM   [LepInfo.Size] = (int)( ( *_electronIDMedium )[el] );
+    LepInfo.EgammaCutBasedEleIdTIGHT    [LepInfo.Size] = (int)( ( *_electronIDTight )[el] );
+    // LepInfo.EgammaCutBasedEleIdHEEP   [LepInfo.Size] = (int)((*fElectronIDHEEP_H)[el]);
     LepInfo.ChargedHadronIso            [LepInfo.Size] = it_el->pfIsolationVariables().sumChargedHadronPt;
     LepInfo.NeutralHadronIso            [LepInfo.Size] = it_el->pfIsolationVariables().sumPhotonEt;
     LepInfo.PhotonIso                   [LepInfo.Size] = it_el->pfIsolationVariables().sumNeutralHadronEt;


### PR DESCRIPTION
After release 9_1_0,  unscheduled tool like
```python
process.options.allowUnscheduled = cms.untracked.bool(True)
```
no longer works so that some external modules will not link with bprimekit. Among some modules, some module associated with electrion ID lose link so that output root file will lose the information of electron ID very much. Therefore, I extract `process.egmGsfElectronIDSequence` from 
https://github.com/cms-sw/cmssw/blob/master/RecoEgamma/ElectronIdentification/python/egmGsfElectronIDs_cff.py#L19
which uses `Task()` new unscheduled tool and add into `path()` to fix this problem.