### PR TITLE
Update global tag and add probbb

### DIFF
--- a/python/bprimeKit_DataRun2017_PromptReco.py
+++ b/python/bprimeKit_DataRun2017_PromptReco.py
@@ -14,7 +14,7 @@ import bpkFrameWork.bprimeKit.Ntuplizer_cfi as ntpl
 #   Additional tag settings
 #-------------------------------------------------------------------------------
 isData               = True
-GlobalTag            = '92X_dataRun2_Prompt_v8'
+GlobalTag            = '92X_dataRun2_Prompt_v10'
 ElectronIDHEEPModule = 'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff'
 ElectronIDModule     = 'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff'
 PhotonIDModule       = 'RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff'

--- a/python/jettoolbox_settings.py
+++ b/python/jettoolbox_settings.py
@@ -16,8 +16,11 @@ listBtagDiscriminators = [
     #Deep CSV
     'pfDeepCSVJetTags:probb',
     'pfDeepCSVJetTags:probc',
-    'pfDeepCSVJetTags:probudsg'
-#    'pfDeepCSVJetTags:probbb'
+    'pfDeepCSVJetTags:probudsg',
+    'pfDeepCSVJetTags:probbb',
+#    'pfDeepCSVJetTags:probcc',
+    'pfCombinedSecondaryVertexV2BJetTags',
+    'pfCombinedMVAV2BJetTags'
 ]
 
 ak4Cut='pt > 25 && abs(eta) < 5.'

--- a/src/JetNtuplizer.cc
+++ b/src/JetNtuplizer.cc
@@ -143,11 +143,11 @@ JetNtuplizer::Analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
       = it_jet->bDiscriminator( "pfDeepCSVJetTags:probc"                       );
     JetInfo.pfJetProbabilityBJetTags[JetInfo.Size]
       = it_jet->bDiscriminator( "pfDeepCSVJetTags:probudsg"                    );
-    //Old b-tagging discriminators
     JetInfo.pfTrackCountingHighPurBJetTags[JetInfo.Size]
-      = it_jet->bDiscriminator( "pfTrackCountingHighPurBJetTags"               );
-    JetInfo.pfTrackCountingHighEffBJetTags[JetInfo.Size]
-      = it_jet->bDiscriminator( "pfTrackCountingHighEffBJetTags"               );
+      = it_jet->bDiscriminator( "pfDeepCSVJetTags:probbb"                      );
+    //JetInfo.pfTrackCountingHighEffBJetTags[JetInfo.Size]
+    //  = it_jet->bDiscriminator( "pfDeepCSVJetTags:probcc"                      );
+    //Old b-tagging discriminators
     JetInfo.pfSimpleSecondaryVertexHighEffBJetTags[JetInfo.Size]
       = it_jet->bDiscriminator( "pfSimpleSecondaryVertexHighEffBJetTags"       );
     JetInfo.pfSimpleSecondaryVertexHighPurBJetTags[JetInfo.Size]


### PR DESCRIPTION
Update the global tag corresponding to CMSSW_9_2_13 and add "pfDeepCSVJetTags:probbb" and "pfDeepCSVJetTags:probcc" but "pfDeepCSVJetTags:probcc" can not be supported in the current cmssw release(CMSSW_9_2_13).